### PR TITLE
Examples: Add call to function EplApiProcessImageFree() in the demo_kerne

### DIFF
--- a/Examples/X86/Linux/gnu/demo_kernel/demo_main.c
+++ b/Examples/X86/Linux/gnu/demo_kernel/demo_main.c
@@ -558,6 +558,12 @@ tEplKernel          EplRet;
     {   // waiting was interrupted by signal or application called wrong function
         EplRet = kEplShutdown;
     }*/
+
+#ifdef CONFIG_OPENCONFIGURATOR_MAPPING
+    // Free resources used by the process image API
+    EplRet = EplApiProcessImageFree();
+#endif
+
     // delete instance for all modules
     EplRet = EplApiShutdown();
     PRINTF1("EplApiShutdown():  0x%X\n", EplRet);

--- a/Examples/X86/Linux/gnu/demo_process_image_console/demo_main.c
+++ b/Examples/X86/Linux/gnu/demo_process_image_console/demo_main.c
@@ -595,6 +595,10 @@ ExitShutdown:
     // halt the NMT state machine
     // so the processing of POWERLINK frames stops
     EplRet = EplApiExecNmtCommand(kEplNmtEventSwitchOff);
+
+    // Free resources used by the process image API
+    EplRet = EplApiProcessImageFree();
+
     // delete instance for all modules
     EplRet = EplApiShutdown();
 


### PR DESCRIPTION
Some examples that use the process image API call the function EplApiProcessImageFree() at shutdown, others don't. This commit adds the missing call to the other examples.

Examples: Add call to function EplApiProcessImageFree() in the demo_kernel and demo_process_image_console examples.
