### PR TITLE
EplSyncu: Add guards to prevent compilation errors.

### DIFF
--- a/EplStack/EplSyncu.c
+++ b/EplStack/EplSyncu.c
@@ -68,6 +68,8 @@
 
 ****************************************************************************/
 
+#if EPL_DLL_PRES_CHAINING_MN != FALSE
+
 #include "user/EplSyncu.h"
 #include "user/EplDlluCal.h"
 
@@ -370,6 +372,8 @@ tEplSyncuCbResponse pfnCbResponse;
 Exit:
     return Ret;
 }
+
+#endif // EPL_DLL_PRES_CHAINING_MN != FALSE
 
 // EOF
 

--- a/Include/user/EplSyncu.h
+++ b/Include/user/EplSyncu.h
@@ -72,6 +72,8 @@
 #ifndef _EPLSYNCU_H_
 #define _EPLSYNCU_H_
 
+#if EPL_DLL_PRES_CHAINING_MN != FALSE
+
 #include "EplDll.h"
 
 
@@ -104,6 +106,8 @@ tEplKernel PUBLIC EplSyncuRequestSyncResponse(
                                   tEplSyncuCbResponse   pfnCbResponse_p,
                                   tEplDllSyncRequest*   pSyncRequestData_p,
                                   unsigned int          uiSize_p);
+
+#endif // EPL_DLL_PRES_CHAINING_MN != FALSE
 
 #endif  // #ifndef _EPLSYNCU_H_
 


### PR DESCRIPTION
If EPL_DLL_PRES_CHAINING_MN is defined as FALSE in EplCfg.h, the stack won't compile:

Error message:

EplStack/EplSyncu.c:71: 
Include/user/EplSyncu.h:105: error: expected declaration specifiers or ‘...’ before ‘tEplDllSyncRequest’
EplStack/EplSyncu.c: In function ‘EplSyncuAddInstance’:
EplStack/EplSyncu.c:199: error: ‘kEplDllAsndSyncResponse’ undeclared (first use in this function)
EplStack/EplSyncu.c:199: error: (Each undeclared identifier is reported only once
EplStack/EplSyncu.c:199: error: for each function it appears in.)
EplStack/EplSyncu.c: In function ‘EplSyncuDelInstance’:
EplStack/EplSyncu.c:226: error: ‘kEplDllAsndSyncResponse’ undeclared (first use in this function)
EplStack/EplSyncu.c: At top level:
EplStack/EplSyncu.c:279: error: expected declaration specifiers or ‘...’ before ‘tEplDllSyncRequest’
EplStack/EplSyncu.c: In function ‘EplSyncuRequestSyncResponse’:
EplStack/EplSyncu.c:286: error: ‘pSyncRequestData_p’ undeclared (first use in this function)
EplStack/EplSyncu.c:305: warning: implicit declaration of function ‘EplDlluCalIssueSyncRequest’

---

The reason is, that parts of the stack (e.g. the type definition for tEplDllSyncRequest in EplDll.h) are guarded by EPL_DLL_PRES_CHAINING_MN, while the header and source file for EplSync (who use this type def) are not.
