### PR TITLE
MN NMT state in object 0x1F8E

### DIFF
--- a/EplStack/EplNmtMnu.c
+++ b/EplStack/EplNmtMnu.c
@@ -969,7 +969,17 @@ Exit:
 
 tEplKernel PUBLIC EplNmtMnuCbNmtStateChange(tEplEventNmtStateChange NmtStateChange_p)
 {
-tEplKernel      Ret = kEplSuccessful;
+    tEplKernel      Ret = kEplSuccessful;
+    BYTE            NewMnNmtState;
+
+    // Save new MN state in object 0x1F8E
+    NewMnNmtState   = (BYTE) NmtStateChange_p.m_NewNmtState;
+
+    Ret = EplObdWriteEntry(0x1F8E, 240, &NewMnNmtState, 1);
+    if(Ret != kEplSuccessful)
+    {
+        return  Ret;
+    }
 
     // do work which must be done in that state
     switch (NmtStateChange_p.m_NewNmtState)

--- a/ObjDicts/Generic/objdict_1b00-1fff.h
+++ b/ObjDicts/Generic/objdict_1b00-1fff.h
@@ -125,7 +125,7 @@
 
         // Object 1F8Ch: NMT_CurrNMTState_U8
         EPL_OBD_BEGIN_INDEX_RAM(0x1F8C, 0x01, NULL)
-            EPL_OBD_SUBINDEX_RAM_VAR(0x1F8C, 0x00, kEplObdTypUInt8, (kEplObdAccR | kEplObdAccPdo), tEplObdUnsigned8, NMT_CurrNMTState_U8, 0x00)
+            EPL_OBD_SUBINDEX_RAM_VAR(0x1F8C, 0x00, kEplObdTypUInt8, (kEplObdAccR | kEplObdAccPdo), tEplObdUnsigned8, NMT_CurrNMTState_U8, 0x1C)
         EPL_OBD_END_INDEX(0x1F8C)
 
 #if EPL_NMT_MAX_NODE_ID > 0


### PR DESCRIPTION
MN should save its own NMT state in object 0x1F8E/240.
Additionally, this branch fixes the default value of object 0x1F8C (should be 0x1C according to spec).
