### PR TITLE
Demo_kernel: Call EplApiFreeProcessImage.

### DIFF
--- a/Examples/X86/Linux/gnu/demo_kernel/demo_main.c
+++ b/Examples/X86/Linux/gnu/demo_kernel/demo_main.c
@@ -558,6 +558,12 @@ tEplKernel          EplRet;
     {   // waiting was interrupted by signal or application called wrong function
         EplRet = kEplShutdown;
     }*/
+
+#ifdef CONFIG_OPENCONFIGURATOR_MAPPING
+    // Free resources used by the process image API
+    EplRet = EplApiProcessImageFree();
+#endif
+
     // delete instance for all modules
     EplRet = EplApiShutdown();
     PRINTF1("EplApiShutdown():  0x%X\n", EplRet);


### PR DESCRIPTION
The kernel space demo does not free the process image on shutdown.
