### PR TITLE
SdoSequ: Fix handling of unsupported SDO sequence layer protocols.

### DIFF
--- a/EplStack/EplSdoAsySequ.c
+++ b/EplStack/EplSdoAsySequ.c
@@ -479,6 +479,7 @@ tEplAsySdoSeqCon*   pAsySdoSeqCon;
             }
 #else
             Ret = kEplSdoSeqUnsupportedProt;
+            goto Exit;
 #endif
             break;
         }
@@ -495,6 +496,7 @@ tEplAsySdoSeqCon*   pAsySdoSeqCon;
             }
 #else
             Ret = kEplSdoSeqUnsupportedProt;
+            goto Exit;
 #endif
             break;
         }


### PR DESCRIPTION
This branch fixes a bug in EplSdoAsySequ.

Unsupported protocols don't lead to a return value of kEplUnsupportedProtocol, instead the stack tries to allocate resources.
