### PR TITLE
EplSyncu: Add guards to prevent compilation errors.

### DIFF
--- a/EplStack/EplSyncu.c
+++ b/EplStack/EplSyncu.c
@@ -68,6 +68,8 @@
 
 ****************************************************************************/
 
+#if EPL_DLL_PRES_CHAINING_MN != FALSE
+
 #include "user/EplSyncu.h"
 #include "user/EplDlluCal.h"
 
@@ -370,6 +372,8 @@ tEplSyncuCbResponse pfnCbResponse;
 Exit:
     return Ret;
 }
+
+#endif // EPL_DLL_PRES_CHAINING_MN != FALSE
 
 // EOF
 

--- a/Include/user/EplSyncu.h
+++ b/Include/user/EplSyncu.h
@@ -72,6 +72,8 @@
 #ifndef _EPLSYNCU_H_
 #define _EPLSYNCU_H_
 
+#if EPL_DLL_PRES_CHAINING_MN != FALSE
+
 #include "EplDll.h"
 
 
@@ -104,6 +106,8 @@ tEplKernel PUBLIC EplSyncuRequestSyncResponse(
                                   tEplSyncuCbResponse   pfnCbResponse_p,
                                   tEplDllSyncRequest*   pSyncRequestData_p,
                                   unsigned int          uiSize_p);
+
+#endif // EPL_DLL_PRES_CHAINING_MN != FALSE
 
 #endif  // #ifndef _EPLSYNCU_H_
 


### PR DESCRIPTION
If EPL_DLL_PRES_CHAINING_MN is defined as FALSE in EplCfg.h, the stack won't compile.
The reason is, that parts of the stack (e.g. the type definition for tEplDllSyncRequest in EplDll.h) are guarded by EPL_DLL_PRES_CHAINING_MN, while the header and source file for EplSync (who use this type def) are not.
