### PR TITLE
Add dummy EplApiGetIdentResponse() function to EplApiLinuxUser.

### DIFF
--- a/EplStack/EplApiLinuxUser.c
+++ b/EplStack/EplApiLinuxUser.c
@@ -1005,6 +1005,32 @@ int             iRet;
 }
 #endif
 
+//---------------------------------------------------------------------------
+//
+// Function:    EplApiGetIdentResponse
+//
+// Description: returns the stored IdentResponse frame of the specified node.
+//
+// Parameters:  uiNodeId_p              = node-ID for which the IdentResponse shall be returned
+//              ppIdentResponse_p       = pointer to pointer to IdentResponse
+//
+// Returns:     tEplKernel              = error code
+//
+//
+// State:
+//
+//---------------------------------------------------------------------------
+
+tEplKernel PUBLIC EplApiGetIdentResponse(
+                                    unsigned int        uiNodeId_p,
+                                    tEplIdentResponse** ppIdentResponse_p)
+{
+    // This function is currently not supported
+    // in the Linux kernel space implementation
+    *ppIdentResponse_p  = NULL;
+
+    return  kEplInvalidOperation;
+}
 
 //=========================================================================//
 //                                                                         //


### PR DESCRIPTION
The current Linux user space/kernel space wrapper does not provide the function EplApiGetIdentResponse.
An application that calls this function on e.g. Windows fails to link with the API wrapper.

This commit adds a dummy function that always returns kInvalidOperation.
